### PR TITLE
Make the default SDK version 0.7.5 and correct link to phusion base image in the readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM phusion/baseimage:0.9.18
 MAINTAINER marshall@kubos.co
 
-ARG SDK_VERSION=0.7.2
+ARG SDK_VERSION=0.7.5
 
 ENV ZEPHYR_BASE            /build
 ENV PATH                   $PATH:$ZEPHYR_BASE/scripts

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ on the [Zephyr Project](http://zephyrproject.org) RTOS from the Linux Foundation
 2. Build and run the `hello_world` example in qemu
 
         $ cd ~/zephyr-project
-        $ docker run -v $PWD:/build -w /build/samples/microkernel/apps/hello_world -it marshallc/zephyr-project make qemu
+        $ docker run -v $PWD:/build -w /build/samples/hello_world/microkernel -it marshallc/zephyr-project make qemu

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ on the [Zephyr Project](http://zephyrproject.org) RTOS from the Linux Foundation
 
 ### What's included
 
-* Based on v0.9.18 of phusion's modified ubuntu [baseimage](https://github.com/phusion/baseimage)
-* Zephyr SDK v0.7.2 installed at `/opt/zephyr-sdk` (can be overridden and rebuilt with the build argument `SDK_VERSION`)
+* Based on v0.9.18 of phusion's modified ubuntu [baseimage](https://github.com/phusion/baseimage-docker)
+* Zephyr SDK v0.7.5 installed at `/opt/zephyr-sdk` (can be overridden and rebuilt with the build argument `SDK_VERSION`)
 * python / make / gcc and friends
 
 ### Example w/ Hello World


### PR DESCRIPTION
Hi, 

I was using your docker image and I noticed that there is a newer zephyr SDK version available and that there were a couple of things wrong in the readme file - firstly that the link to the phusion basimage did not work and that (probably because I changed the SDK version to 0.7.5) the path to the hello world example was not right.

Perhaps you want these changes, I don't know.  Thank you for making this docker image anyway, it is awesome!

Kevin
